### PR TITLE
Remove Integration notes section from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,9 +21,3 @@ This work based on [Matt Bierner's work](https://github.com/mjbvz/vscode-fenced-
 This extension does not add the grammar; it only connects Markdown ASM code blocks to the existing ASM grammar.
 
 For this reason, it requires a preexisting extension that provides the grammar, for example, [nasm x86 syntax highlighting](https://marketplace.visualstudio.com/items?itemName=LucianIrsigler.nasm).
-
-## Integration notes
-
-When integrating into an existing project, a new language id entry needs to be added; if an existing one is recycled, the grammar will apply only to the new scope.
-
-See [PR on ASM Code Lens](https://github.com/maziac/asm-code-lens/pull/65).

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "markdown-code-blocks-asm-syntax-highlighting",
   "displayName": "Markdown Code blocks Assembly Syntax highlighting",
   "description": "",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "publisher": "64kramsystem",
   "license": "MIT",
   "repository": {


### PR DESCRIPTION
They don't make sense anymore, as the extension is now not intended to be used as reference for extensions development anymore.